### PR TITLE
feat: Add custom entries for camps, art, and events

### DIFF
--- a/src/components/FloatingActionButton.vue
+++ b/src/components/FloatingActionButton.vue
@@ -1,0 +1,121 @@
+<template>
+  <button 
+    class="fab"
+    :class="{ 'fab-hidden': hidden }"
+    @click="$emit('click')"
+    :aria-label="label"
+  >
+    <span class="fab-icon">{{ icon }}</span>
+  </button>
+</template>
+
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+
+const props = defineProps({
+  icon: {
+    type: String,
+    default: '+'
+  },
+  label: {
+    type: String,
+    default: 'Add'
+  }
+})
+
+const hidden = ref(false)
+let lastScrollY = window.scrollY
+let scrollTimeout = null
+
+// Hide FAB on scroll down, show on scroll up
+const handleScroll = () => {
+  const currentScrollY = window.scrollY
+  
+  if (scrollTimeout) {
+    clearTimeout(scrollTimeout)
+  }
+  
+  // Hide when scrolling down
+  if (currentScrollY > lastScrollY && currentScrollY > 100) {
+    hidden.value = true
+  } else {
+    hidden.value = false
+  }
+  
+  lastScrollY = currentScrollY
+  
+  // Show after scroll stops
+  scrollTimeout = setTimeout(() => {
+    hidden.value = false
+  }, 1000)
+}
+
+onMounted(() => {
+  window.addEventListener('scroll', handleScroll, { passive: true })
+})
+
+onUnmounted(() => {
+  window.removeEventListener('scroll', handleScroll)
+  if (scrollTimeout) {
+    clearTimeout(scrollTimeout)
+  }
+})
+</script>
+
+<style scoped>
+.fab {
+  position: fixed;
+  bottom: calc(70px + env(safe-area-inset-bottom)); /* Above bottom nav */
+  right: 16px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background-color: #8B0000;
+  color: white;
+  border: none;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  z-index: 100;
+  transition: all 0.3s ease;
+  font-size: 24px;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.fab:hover {
+  background-color: #a00000;
+  transform: scale(1.05);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.4);
+}
+
+.fab:active {
+  transform: scale(0.95);
+}
+
+.fab-hidden {
+  transform: translateY(100px);
+  opacity: 0;
+}
+
+.fab-icon {
+  font-size: 28px;
+  line-height: 1;
+}
+
+/* Tablet and desktop adjustments */
+@media (min-width: 768px) {
+  .fab {
+    bottom: 24px;
+    right: 24px;
+  }
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+  .fab {
+    transition: none;
+  }
+}
+</style>

--- a/src/components/FormModal.vue
+++ b/src/components/FormModal.vue
@@ -1,0 +1,241 @@
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <div v-if="modelValue" class="modal-backdrop" @click="handleBackdropClick">
+        <div class="modal-container" @click.stop>
+          <header class="modal-header">
+            <h2>{{ title }}</h2>
+            <button @click="$emit('update:modelValue', false)" class="close-btn" aria-label="Close">
+              ×
+            </button>
+          </header>
+          
+          <div class="modal-body">
+            <slot></slot>
+          </div>
+          
+          <footer class="modal-footer">
+            <button @click="$emit('update:modelValue', false)" class="btn btn-secondary">
+              Cancel
+            </button>
+            <button @click="handleSave" class="btn btn-primary" :disabled="!isValid || saving">
+              {{ saving ? 'Saving...' : 'Save' }}
+            </button>
+          </footer>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup>
+import { watch, onMounted, onUnmounted } from 'vue'
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false
+  },
+  title: {
+    type: String,
+    required: true
+  },
+  isValid: {
+    type: Boolean,
+    default: false
+  },
+  saving: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const emit = defineEmits(['update:modelValue', 'save'])
+
+const handleBackdropClick = () => {
+  emit('update:modelValue', false)
+}
+
+const handleSave = () => {
+  if (props.isValid && !props.saving) {
+    emit('save')
+  }
+}
+
+// Handle escape key
+const handleEscape = (e) => {
+  if (e.key === 'Escape' && props.modelValue) {
+    emit('update:modelValue', false)
+  }
+}
+
+// Prevent body scroll when modal is open
+watch(() => props.modelValue, (isOpen) => {
+  if (isOpen) {
+    document.body.style.overflow = 'hidden'
+    document.addEventListener('keydown', handleEscape)
+  } else {
+    document.body.style.overflow = ''
+    document.removeEventListener('keydown', handleEscape)
+  }
+})
+
+onUnmounted(() => {
+  document.body.style.overflow = ''
+  document.removeEventListener('keydown', handleEscape)
+})
+</script>
+
+<style scoped>
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.modal-container {
+  background-color: #2a2a2a;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 600px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+}
+
+.modal-header {
+  padding: 1.5rem;
+  border-bottom: 1px solid #444;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+
+.modal-header h2 {
+  margin: 0;
+  color: #fff;
+  font-size: 1.5rem;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  color: #999;
+  font-size: 2rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s;
+}
+
+.close-btn:hover {
+  color: #fff;
+}
+
+.modal-body {
+  padding: 1.5rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.modal-footer {
+  padding: 1.5rem;
+  border-top: 1px solid #444;
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+  flex-shrink: 0;
+}
+
+.btn {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: inherit;
+}
+
+.btn-primary {
+  background-color: #8B0000;
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background-color: #a00000;
+}
+
+.btn-primary:disabled {
+  background-color: #444;
+  color: #999;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background-color: #444;
+  color: #ccc;
+}
+
+.btn-secondary:hover {
+  background-color: #555;
+  color: #fff;
+}
+
+/* Mobile adjustments */
+@media (max-width: 600px) {
+  .modal-backdrop {
+    padding: 0;
+  }
+  
+  .modal-container {
+    max-width: 100%;
+    width: 100%;
+    height: 100%;
+    max-height: 100%;
+    border-radius: 0;
+  }
+  
+  .modal-header,
+  .modal-body,
+  .modal-footer {
+    padding: 1rem;
+  }
+}
+
+/* Transitions */
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.modal-enter-active .modal-container,
+.modal-leave-active .modal-container {
+  transition: transform 0.3s ease;
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+
+.modal-enter-from .modal-container,
+.modal-leave-to .modal-container {
+  transform: scale(0.9);
+}
+</style>

--- a/src/components/LocationPicker.vue
+++ b/src/components/LocationPicker.vue
@@ -1,0 +1,350 @@
+<template>
+  <div class="location-picker">
+    <div class="location-tabs">
+      <button 
+        @click="mode = 'intersection'"
+        :class="['tab', { active: mode === 'intersection' }]"
+      >
+        Intersection
+      </button>
+      <button 
+        @click="mode = 'gps'"
+        :class="['tab', { active: mode === 'gps' }]"
+      >
+        GPS Coordinates
+      </button>
+    </div>
+    
+    <div v-if="mode === 'intersection'" class="intersection-mode">
+      <div class="form-group">
+        <label for="clock-position">Clock Position</label>
+        <select 
+          id="clock-position"
+          v-model="intersection.clockPosition"
+          @change="updateLocation"
+          class="form-control"
+        >
+          <option value="">Select position</option>
+          <option value="2:00">2:00</option>
+          <option value="2:30">2:30</option>
+          <option value="3:00">3:00</option>
+          <option value="3:30">3:30</option>
+          <option value="4:00">4:00</option>
+          <option value="4:30">4:30</option>
+          <option value="5:00">5:00</option>
+          <option value="5:30">5:30</option>
+          <option value="6:00">6:00</option>
+          <option value="6:30">6:30</option>
+          <option value="7:00">7:00</option>
+          <option value="7:30">7:30</option>
+          <option value="8:00">8:00</option>
+          <option value="8:30">8:30</option>
+          <option value="9:00">9:00</option>
+          <option value="9:30">9:30</option>
+          <option value="10:00">10:00</option>
+          <option value="10:30">10:30</option>
+        </select>
+      </div>
+      
+      <div class="form-group">
+        <label for="street">Street</label>
+        <select 
+          id="street"
+          v-model="intersection.street"
+          @change="updateLocation"
+          class="form-control"
+        >
+          <option value="">Select street</option>
+          <option value="Esplanade">Esplanade</option>
+          <option value="A">A</option>
+          <option value="B">B</option>
+          <option value="C">C</option>
+          <option value="D">D</option>
+          <option value="E">E</option>
+          <option value="F">F</option>
+          <option value="G">G</option>
+          <option value="H">H</option>
+          <option value="I">I</option>
+          <option value="J">J</option>
+          <option value="K">K</option>
+          <option value="L">L</option>
+        </select>
+      </div>
+      
+      <div class="form-group">
+        <label for="intersection-type">Intersection Type</label>
+        <select 
+          id="intersection-type"
+          v-model="intersection.type"
+          @change="updateLocation"
+          class="form-control"
+        >
+          <option value="&">&amp; (Intersection)</option>
+          <option value="@">@ (Plaza)</option>
+        </select>
+      </div>
+      
+      <div v-if="locationString" class="location-preview">
+        <strong>Location:</strong> {{ locationString }}
+      </div>
+    </div>
+    
+    <div v-else-if="mode === 'gps'" class="gps-mode">
+      <div class="form-group">
+        <label for="latitude">Latitude</label>
+        <input 
+          id="latitude"
+          v-model.number="gps.latitude"
+          @input="updateLocation"
+          type="number"
+          step="0.000001"
+          min="-90"
+          max="90"
+          placeholder="40.786958"
+          class="form-control"
+        >
+      </div>
+      
+      <div class="form-group">
+        <label for="longitude">Longitude</label>
+        <input 
+          id="longitude"
+          v-model.number="gps.longitude"
+          @input="updateLocation"
+          type="number"
+          step="0.000001"
+          min="-180"
+          max="180"
+          placeholder="-119.202994"
+          class="form-control"
+        >
+      </div>
+      
+      <button 
+        @click="getCurrentLocation"
+        class="btn btn-secondary"
+        :disabled="gettingLocation"
+      >
+        {{ gettingLocation ? 'Getting location...' : 'Use Current Location' }}
+      </button>
+      
+      <div v-if="gpsError" class="error-message">
+        {{ gpsError }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+
+const props = defineProps({
+  modelValue: {
+    type: Object,
+    default: () => ({})
+  }
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const mode = ref('intersection')
+const gettingLocation = ref(false)
+const gpsError = ref('')
+
+const intersection = ref({
+  clockPosition: '',
+  street: '',
+  type: '&'
+})
+
+const gps = ref({
+  latitude: null,
+  longitude: null
+})
+
+const locationString = computed(() => {
+  if (mode.value === 'intersection' && intersection.value.clockPosition && intersection.value.street) {
+    return `${intersection.value.clockPosition} ${intersection.value.type} ${intersection.value.street}`
+  } else if (mode.value === 'gps' && gps.value.latitude && gps.value.longitude) {
+    return `GPS: ${gps.value.latitude}, ${gps.value.longitude}`
+  }
+  return ''
+})
+
+const updateLocation = () => {
+  let location = {}
+  
+  if (mode.value === 'intersection' && intersection.value.clockPosition && intersection.value.street) {
+    location = {
+      intersection: intersection.value.clockPosition,
+      intersection_type: intersection.value.type,
+      street: intersection.value.street,
+      location_string: locationString.value
+    }
+  } else if (mode.value === 'gps' && gps.value.latitude && gps.value.longitude) {
+    location = {
+      gps_latitude: gps.value.latitude,
+      gps_longitude: gps.value.longitude,
+      location_string: locationString.value
+    }
+  }
+  
+  emit('update:modelValue', location)
+}
+
+const getCurrentLocation = async () => {
+  if (!navigator.geolocation) {
+    gpsError.value = 'Geolocation is not supported by your browser'
+    return
+  }
+  
+  gettingLocation.value = true
+  gpsError.value = ''
+  
+  try {
+    const position = await new Promise((resolve, reject) => {
+      navigator.geolocation.getCurrentPosition(resolve, reject, {
+        enableHighAccuracy: true,
+        timeout: 10000,
+        maximumAge: 0
+      })
+    })
+    
+    gps.value.latitude = position.coords.latitude
+    gps.value.longitude = position.coords.longitude
+    updateLocation()
+  } catch (error) {
+    gpsError.value = 'Unable to get your location. Please enter manually.'
+  } finally {
+    gettingLocation.value = false
+  }
+}
+
+// Initialize from modelValue
+watch(() => props.modelValue, (value) => {
+  if (value && value.intersection) {
+    mode.value = 'intersection'
+    intersection.value = {
+      clockPosition: value.intersection,
+      street: value.street || '',
+      type: value.intersection_type || '&'
+    }
+  } else if (value && value.gps_latitude) {
+    mode.value = 'gps'
+    gps.value = {
+      latitude: value.gps_latitude,
+      longitude: value.gps_longitude
+    }
+  }
+}, { immediate: true })
+</script>
+
+<style scoped>
+.location-picker {
+  margin-bottom: 1.5rem;
+}
+
+.location-picker h3 {
+  color: #ccc;
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
+}
+
+.location-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tab {
+  flex: 1;
+  padding: 0.5rem 1rem;
+  background-color: #333;
+  color: #999;
+  border: 1px solid #444;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 0.9rem;
+}
+
+.tab.active {
+  background-color: #8B0000;
+  color: white;
+  border-color: #8B0000;
+}
+
+.tab:hover:not(.active) {
+  background-color: #444;
+  color: #ccc;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  color: #ccc;
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.form-control {
+  width: 100%;
+  padding: 0.75rem;
+  background-color: #333;
+  color: #fff;
+  border: 1px solid #444;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.form-control:focus {
+  outline: none;
+  border-color: #8B0000;
+  background-color: #3a3a3a;
+}
+
+.location-preview {
+  padding: 0.75rem;
+  background-color: #333;
+  border-radius: 4px;
+  margin-top: 1rem;
+  color: #ccc;
+}
+
+.error-message {
+  color: #ff6666;
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.btn {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: inherit;
+}
+
+.btn-secondary {
+  background-color: #444;
+  color: #ccc;
+  margin-top: 1rem;
+  width: 100%;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background-color: #555;
+  color: #fff;
+}
+
+.btn-secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/src/components/forms/CustomArtForm.vue
+++ b/src/components/forms/CustomArtForm.vue
@@ -1,0 +1,69 @@
+<template>
+  <CustomEntryForm
+    v-model="show"
+    :year="props.year"
+    entry-type="art"
+    name-label="Art Installation Name"
+    name-placeholder="e.g., Temple of Gravity"
+    description-placeholder="Describe your art installation..."
+    contact-placeholder="artist@example.com"
+    :show-url-field="true"
+    :additional-fields="{ artist: '', artist_location: '' }"
+    @saved="handleSaved"
+  >
+    <template #type-fields="{ formData, errors }">
+      <div class="form-group">
+        <label for="art-artist" class="required">Artist Name</label>
+        <input
+          id="art-artist"
+          v-model="formData.artist"
+          type="text"
+          class="form-control"
+          placeholder="e.g., Jane Doe"
+          required
+          autocomplete="off"
+        >
+        <div v-if="errors.artist" class="error-message">{{ errors.artist }}</div>
+      </div>
+      
+      <div class="form-group">
+        <label for="art-artist-location">Artist Location</label>
+        <input
+          id="art-artist-location"
+          v-model="formData.artist_location"
+          type="text"
+          class="form-control"
+          placeholder="e.g., Oakland, CA"
+          autocomplete="off"
+        >
+      </div>
+    </template>
+  </CustomEntryForm>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import CustomEntryForm from './CustomEntryForm.vue'
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false
+  },
+  year: {
+    type: String,
+    required: true
+  }
+})
+
+const emit = defineEmits(['update:modelValue', 'saved'])
+
+const show = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value)
+})
+
+const handleSaved = (uid) => {
+  emit('saved', uid)
+}
+</script>

--- a/src/components/forms/CustomCampForm.vue
+++ b/src/components/forms/CustomCampForm.vue
@@ -1,0 +1,55 @@
+<template>
+  <CustomEntryForm
+    v-model="show"
+    :year="props.year"
+    entry-type="camp"
+    name-label="Camp Name"
+    name-placeholder="e.g., Dusty Oasis"
+    description-placeholder="What makes this camp special?"
+    contact-placeholder="camp@example.com"
+    :show-url-field="true"
+    :additional-fields="{ hometown: '' }"
+    @saved="handleSaved"
+  >
+    <template #type-fields="{ formData, errors }">
+      <div class="form-group">
+        <label for="camp-hometown">Hometown</label>
+        <input
+          id="camp-hometown"
+          v-model="formData.hometown"
+          type="text"
+          class="form-control"
+          placeholder="e.g., San Francisco, CA"
+          autocomplete="off"
+        >
+      </div>
+    </template>
+  </CustomEntryForm>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import CustomEntryForm from './CustomEntryForm.vue'
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false
+  },
+  year: {
+    type: String,
+    required: true
+  }
+})
+
+const emit = defineEmits(['update:modelValue', 'saved'])
+
+const show = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value)
+})
+
+const handleSaved = (uid) => {
+  emit('saved', uid)
+}
+</script>

--- a/src/components/forms/CustomEntryForm.vue
+++ b/src/components/forms/CustomEntryForm.vue
@@ -1,0 +1,436 @@
+<template>
+  <FormModal
+    v-model="show"
+    :title="`Add Custom ${capitalize(props.entryType)}`"
+    :is-valid="isFormValid"
+    :saving="saving"
+    @save="handleSave"
+  >
+    <form @submit.prevent="handleSave" class="custom-form">
+      <!-- Primary Information -->
+      <div class="form-section">
+        <h3 class="section-title">{{ sectionTitle }}</h3>
+        
+        <div class="form-group">
+          <label :for="`${entryType}-name`" class="required">{{ nameLabel }}</label>
+          <input
+            :id="`${entryType}-name`"
+            v-model="formData.name"
+            type="text"
+            class="form-control"
+            :placeholder="namePlaceholder"
+            required
+            autocomplete="off"
+          >
+          <div v-if="errors.name" class="error-message">{{ errors.name }}</div>
+        </div>
+        
+        <div class="form-group">
+          <label :for="`${entryType}-description`">Description</label>
+          <textarea
+            :id="`${entryType}-description`"
+            v-model="formData.description"
+            class="form-control"
+            rows="3"
+            :placeholder="descriptionPlaceholder"
+          ></textarea>
+        </div>
+        
+        <!-- Type-specific fields -->
+        <slot name="type-fields" :formData="formData" :errors="errors" :updateField="updateField"></slot>
+      </div>
+      
+      <!-- Location Section -->
+      <div class="form-section">
+        <h3 class="section-title">Location</h3>
+        <LocationPicker 
+          v-model="formData.location"
+          @update:modelValue="handleLocationUpdate"
+        />
+        <div v-if="formData.location_string" class="location-preview">
+          Location: {{ formData.location_string }}
+        </div>
+      </div>
+      
+      <!-- Additional Information -->
+      <div class="form-section">
+        <h3 class="section-title">Additional Info</h3>
+        
+        <div class="form-group">
+          <label :for="`${entryType}-contact`">Contact Email</label>
+          <input
+            :id="`${entryType}-contact`"
+            v-model="formData.contact_email"
+            type="email"
+            class="form-control"
+            :placeholder="contactPlaceholder"
+            autocomplete="email"
+          >
+          <div v-if="errors.contact_email" class="error-message">{{ errors.contact_email }}</div>
+        </div>
+        
+        <div class="form-group" v-if="showUrlField">
+          <label :for="`${entryType}-url`">Website</label>
+          <input
+            :id="`${entryType}-url`"
+            v-model="formData.url"
+            type="url"
+            class="form-control"
+            placeholder="https:// ..."
+            autocomplete="url"
+          >
+          <div v-if="errors.url" class="error-message">{{ errors.url }}</div>
+        </div>
+        
+        <div class="form-group">
+          <label :for="`${entryType}-notes`">Personal Notes</label>
+          <textarea
+            :id="`${entryType}-notes`"
+            v-model="formData.notes"
+            class="form-control"
+            rows="2"
+            placeholder="Any additional notes for yourself..."
+          ></textarea>
+        </div>
+      </div>
+      
+      <!-- Custom Entry Notice -->
+      <div class="custom-notice">
+        <span class="custom-badge">
+          <span class="badge-icon">✏️</span>
+          <span class="badge-text">CUSTOM ENTRY</span>
+        </span>
+        <p>This {{ entryType }} will be saved locally and marked as a custom entry.</p>
+      </div>
+    </form>
+  </FormModal>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import FormModal from '../FormModal.vue'
+import LocationPicker from '../LocationPicker.vue'
+import { saveCustomEntry } from '../../services/customEntries'
+import { useToast } from '../../composables/useToast'
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false
+  },
+  year: {
+    type: String,
+    required: true
+  },
+  entryType: {
+    type: String,
+    required: true,
+    validator: (value) => ['camp', 'art', 'event'].includes(value)
+  },
+  // Configuration props
+  nameLabel: {
+    type: String,
+    default: 'Name'
+  },
+  namePlaceholder: {
+    type: String,
+    default: ''
+  },
+  descriptionPlaceholder: {
+    type: String,
+    default: 'Describe this entry...'
+  },
+  contactPlaceholder: {
+    type: String,
+    default: 'contact@example.com'
+  },
+  showUrlField: {
+    type: Boolean,
+    default: true
+  },
+  additionalFields: {
+    type: Object,
+    default: () => ({})
+  }
+})
+
+const emit = defineEmits(['update:modelValue', 'saved'])
+
+const { showSuccess, showError } = useToast()
+
+const show = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value)
+})
+
+const sectionTitle = computed(() => {
+  const titles = {
+    camp: 'Camp Details',
+    art: 'Art Installation Details',
+    event: 'Event Details'
+  }
+  return titles[props.entryType] || 'Details'
+})
+
+const formData = ref({
+  name: '',
+  description: '',
+  location: {},
+  location_string: '',
+  contact_email: '',
+  url: '',
+  notes: '',
+  ...props.additionalFields
+})
+
+const errors = ref({})
+const saving = ref(false)
+
+const isFormValid = computed(() => {
+  return formData.value.name && formData.value.name.trim().length > 0
+})
+
+const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1)
+
+const updateField = (field, value) => {
+  formData.value[field] = value
+}
+
+const handleLocationUpdate = (location) => {
+  if (location.intersection && location.street) {
+    formData.value.location_string = `${location.intersection} ${location.intersection_type || '&'} ${location.street}`
+  } else if (location.gps_latitude && location.gps_longitude) {
+    formData.value.location_string = `GPS: ${location.gps_latitude}, ${location.gps_longitude}`
+  } else {
+    formData.value.location_string = ''
+  }
+}
+
+const validateForm = () => {
+  errors.value = {}
+  
+  if (!formData.value.name || formData.value.name.trim().length === 0) {
+    errors.value.name = `${props.nameLabel} is required`
+    return false
+  }
+  
+  if (formData.value.url && !isValidUrl(formData.value.url)) {
+    errors.value.url = 'Please enter a valid URL'
+    return false
+  }
+  
+  if (formData.value.contact_email && !isValidEmail(formData.value.contact_email)) {
+    errors.value.contact_email = 'Please enter a valid email'
+    return false
+  }
+  
+  return true
+}
+
+const isValidUrl = (url) => {
+  try {
+    new URL(url)
+    return true
+  } catch (_) {
+    return false
+  }
+}
+
+const isValidEmail = (email) => {
+  const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  return re.test(email)
+}
+
+const handleSave = async () => {
+  if (!validateForm()) {
+    return
+  }
+  
+  saving.value = true
+  
+  try {
+    // Create a plain object without Vue reactivity
+    const entryData = {
+      name: formData.value.name,
+      title: formData.value.name, // For events
+      description: formData.value.description,
+      location: { ...formData.value.location },
+      location_string: formData.value.location_string,
+      contact_email: formData.value.contact_email,
+      url: formData.value.url,
+      notes: formData.value.notes,
+      year: props.year,
+      // Include any additional fields passed via props
+      ...Object.keys(props.additionalFields).reduce((acc, key) => {
+        acc[key] = formData.value[key]
+        return acc
+      }, {})
+    }
+    
+    const uid = await saveCustomEntry(props.entryType, entryData)
+    
+    showSuccess(`Custom ${props.entryType} added successfully!`)
+    
+    // Reset form
+    formData.value = {
+      name: '',
+      description: '',
+      location: {},
+      location_string: '',
+      contact_email: '',
+      url: '',
+      notes: '',
+      ...props.additionalFields
+    }
+    
+    // Close modal and emit saved event
+    show.value = false
+    emit('saved', uid)
+  } catch (error) {
+    console.error(`Error saving custom ${props.entryType}:`, error)
+    showError(`Failed to save custom ${props.entryType}. Please try again.`)
+  } finally {
+    saving.value = false
+  }
+}
+
+// Reset form when modal is closed
+watch(show, (newValue) => {
+  if (!newValue) {
+    errors.value = {}
+  }
+})
+</script>
+
+<style scoped>
+.custom-form {
+  padding: 0;
+}
+
+.form-section {
+  margin-bottom: 2rem;
+}
+
+.form-section:last-of-type {
+  margin-bottom: 1rem;
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #ccc;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0 0 1rem 0;
+}
+
+.form-group,
+:deep(.form-group) {
+  margin-bottom: 1rem;
+}
+
+.form-group label,
+:deep(.form-group label) {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: #ccc;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.form-group label.required::after,
+:deep(.form-group label.required::after) {
+  content: ' *';
+  color: #ff6666;
+}
+
+.form-control,
+:deep(.form-control) {
+  width: 100%;
+  padding: 0.75rem;
+  background-color: #333;
+  color: #fff;
+  border: 1px solid #444;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-family: inherit;
+  transition: all 0.2s ease;
+}
+
+.form-control:focus,
+:deep(.form-control:focus) {
+  outline: none;
+  border-color: #8B0000;
+  background-color: #3a3a3a;
+}
+
+.form-control::placeholder,
+:deep(.form-control::placeholder) {
+  color: #666;
+}
+
+textarea.form-control,
+:deep(textarea.form-control) {
+  resize: vertical;
+  min-height: 80px;
+}
+
+.error-message {
+  color: #ff6666;
+  font-size: 0.85rem;
+  margin-top: 0.25rem;
+}
+
+.location-preview {
+  padding: 0.75rem;
+  background-color: #2a2a2a;
+  border-radius: 4px;
+  margin-top: 1rem;
+  color: #90CAF9;
+  font-size: 0.9rem;
+}
+
+.custom-notice {
+  background-color: rgba(139, 0, 0, 0.1);
+  border: 1px solid #8B0000;
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.custom-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.375rem 0.875rem;
+  background-color: #8B0000;
+  color: #fff;
+  border-radius: 20px;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  line-height: 1;
+}
+
+.badge-icon {
+  font-size: 1rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  margin-right: 0.375rem;
+}
+
+.badge-text {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+}
+
+.custom-notice p {
+  margin: 0;
+  color: #ccc;
+  font-size: 0.85rem;
+}
+</style>

--- a/src/components/forms/CustomEventForm.vue
+++ b/src/components/forms/CustomEventForm.vue
@@ -1,0 +1,203 @@
+<template>
+  <CustomEntryForm
+    v-model="show"
+    :year="props.year"
+    entry-type="event"
+    name-label="Event Title"
+    name-placeholder="e.g., Sunrise Yoga"
+    description-placeholder="What happens at this event?"
+    contact-placeholder="event@example.com"
+    :show-url-field="false"
+    :additional-fields="{ 
+      camp_name: '',
+      event_type: { label: '', abbr: '' },
+      occurrence_set: []
+    }"
+    @saved="handleSaved"
+  >
+    <template #type-fields="{ formData, errors, updateField }">
+      <div class="form-group">
+        <label for="event-camp">Host Camp (Optional)</label>
+        <input
+          id="event-camp"
+          v-model="formData.camp_name"
+          type="text"
+          class="form-control"
+          placeholder="e.g., Dusty Oasis"
+          autocomplete="off"
+        >
+      </div>
+      
+      <div class="form-group">
+        <label for="event-type" class="required">Event Type</label>
+        <select
+          id="event-type"
+          v-model="selectedEventType"
+          @change="updateEventType(updateField)"
+          class="form-control"
+          required
+        >
+          <option value="">Select event type</option>
+          <option value="work">Class/Workshop</option>
+          <option value="prty">Music/Party</option>
+          <option value="food">Food</option>
+          <option value="care">Self Care</option>
+          <option value="game">Games</option>
+          <option value="yoga">Yoga/Movement</option>
+          <option value="arts">Arts & Crafts</option>
+          <option value="cere">Ritual/Ceremony</option>
+          <option value="live">Live Music</option>
+          <option value="perf">Performance</option>
+        </select>
+      </div>
+      
+      <div class="form-group">
+        <label for="event-date" class="required">Date & Time</label>
+        <div class="datetime-inputs">
+          <input
+            id="event-date"
+            v-model="eventDate"
+            @change="updateDateTime(updateField)"
+            type="date"
+            class="form-control"
+            :min="minDate"
+            :max="maxDate"
+            required
+          >
+          <input
+            v-model="eventTime"
+            @change="updateDateTime(updateField)"
+            type="time"
+            class="form-control"
+            required
+          >
+        </div>
+        <small class="form-text">Burning Man 2025: Aug 25 - Sep 2</small>
+      </div>
+      
+      <div class="form-group">
+        <label for="event-duration">Duration</label>
+        <select
+          id="event-duration"
+          v-model="eventDuration"
+          @change="updateDateTime(updateField)"
+          class="form-control"
+        >
+          <option value="30">30 minutes</option>
+          <option value="60" selected>1 hour</option>
+          <option value="90">1.5 hours</option>
+          <option value="120">2 hours</option>
+          <option value="180">3 hours</option>
+          <option value="240">4 hours</option>
+          <option value="0">All day</option>
+        </select>
+      </div>
+    </template>
+  </CustomEntryForm>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import CustomEntryForm from './CustomEntryForm.vue'
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false
+  },
+  year: {
+    type: String,
+    required: true
+  }
+})
+
+const emit = defineEmits(['update:modelValue', 'saved'])
+
+const show = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value)
+})
+
+// Event-specific data
+const selectedEventType = ref('')
+const eventDate = ref('')
+const eventTime = ref('')
+const eventDuration = ref('60')
+
+// Burning Man 2025 dates
+const minDate = '2025-08-25'
+const maxDate = '2025-09-02'
+
+const eventTypeMap = {
+  work: 'Class/Workshop',
+  prty: 'Music/Party',
+  food: 'Food',
+  care: 'Self Care',
+  game: 'Games',
+  yoga: 'Yoga/Movement',
+  arts: 'Arts & Crafts',
+  cere: 'Ritual/Ceremony',
+  live: 'Live Music',
+  perf: 'Performance'
+}
+
+const updateEventType = (updateField) => {
+  if (selectedEventType.value) {
+    updateField('event_type', {
+      label: eventTypeMap[selectedEventType.value],
+      abbr: selectedEventType.value
+    })
+  }
+}
+
+const updateDateTime = (updateField) => {
+  if (eventDate.value && eventTime.value) {
+    const startDateTime = new Date(`${eventDate.value}T${eventTime.value}:00`)
+    const endDateTime = new Date(startDateTime)
+    
+    if (eventDuration.value === '0') {
+      // All day event
+      endDateTime.setHours(23, 59, 59)
+    } else {
+      // Add duration in minutes
+      endDateTime.setMinutes(endDateTime.getMinutes() + parseInt(eventDuration.value))
+    }
+    
+    updateField('occurrence_set', [{
+      start_time: startDateTime.toISOString(),
+      end_time: endDateTime.toISOString()
+    }])
+  }
+}
+
+const handleSaved = (uid) => {
+  // Reset event-specific fields
+  selectedEventType.value = ''
+  eventDate.value = ''
+  eventTime.value = ''
+  eventDuration.value = '60'
+  
+  emit('saved', uid)
+}
+</script>
+
+<style scoped>
+.datetime-inputs {
+  display: flex;
+  gap: 8px;
+}
+
+.datetime-inputs input[type="date"] {
+  flex: 1.5;
+}
+
+.datetime-inputs input[type="time"] {
+  flex: 1;
+}
+
+.form-text {
+  color: #999;
+  font-size: 0.85rem;
+  margin-top: 0.25rem;
+}
+</style>

--- a/src/services/customEntries.js
+++ b/src/services/customEntries.js
@@ -1,0 +1,260 @@
+import { openDb } from './storage'
+
+/**
+ * Generate a unique ID for custom entries
+ * @param {string} type - 'art', 'camp', or 'event'
+ * @returns {string} Unique ID with custom prefix
+ */
+export function generateCustomId(type) {
+  const timestamp = Date.now()
+  const random = Math.random().toString(36).substr(2, 5)
+  return `custom-${type}-${timestamp}-${random}`
+}
+
+/**
+ * Save a custom entry
+ * @param {string} type - 'art', 'camp', or 'event'
+ * @param {Object} entry - Entry data
+ * @returns {Promise<string>} The saved entry's UID
+ */
+export async function saveCustomEntry(type, entry) {
+  try {
+    const database = await openDb()
+    const tx = database.transaction(type, 'readwrite')
+    const store = tx.objectStore(type)
+    
+    // Ensure entry has required fields
+    const customEntry = {
+      ...entry,
+      uid: entry.uid || generateCustomId(type),
+      isCustom: true,
+      createdAt: entry.createdAt || new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      year: parseInt(entry.year || new Date().getFullYear())
+    }
+    
+    // Ensure location_string for geocoding
+    if (customEntry.location && !customEntry.location_string) {
+      customEntry.location_string = formatLocationString(customEntry.location)
+    }
+    
+    await store.put(customEntry)
+    
+    return new Promise((resolve, reject) => {
+      tx.oncomplete = () => {
+        console.log(`Saved custom ${type}:`, customEntry.uid)
+        resolve(customEntry.uid)
+      }
+      tx.onerror = () => reject(tx.error)
+    })
+  } catch (err) {
+    console.error('Failed to save custom entry:', err)
+    throw err
+  }
+}
+
+/**
+ * Get all custom entries of a type for a year
+ * @param {string} type - 'art', 'camp', or 'event'
+ * @param {string} year - Year as string
+ * @returns {Promise<Array>} Array of custom entries
+ */
+export async function getCustomEntries(type, year) {
+  try {
+    const database = await openDb()
+    const tx = database.transaction(type, 'readonly')
+    const store = tx.objectStore(type)
+    
+    const yearIndex = store.index('year')
+    const range = IDBKeyRange.only(parseInt(year))
+    
+    return new Promise((resolve, reject) => {
+      const request = yearIndex.openCursor(range)
+      const customEntries = []
+      
+      request.onsuccess = (e) => {
+        const cursor = e.target.result
+        if (cursor) {
+          if (cursor.value.isCustom) {
+            customEntries.push(cursor.value)
+          }
+          cursor.continue()
+        } else {
+          resolve(customEntries)
+        }
+      }
+      request.onerror = () => reject(request.error)
+    })
+  } catch (err) {
+    console.error('Failed to get custom entries:', err)
+    return []
+  }
+}
+
+/**
+ * Delete a custom entry
+ * @param {string} type - 'art', 'camp', or 'event'
+ * @param {string} uid - Entry UID
+ * @returns {Promise<void>}
+ */
+export async function deleteCustomEntry(type, uid) {
+  try {
+    const database = await openDb()
+    const tx = database.transaction(type, 'readwrite')
+    const store = tx.objectStore(type)
+    
+    // Verify it's a custom entry before deleting
+    const entry = await store.get(uid)
+    if (!entry || !entry.isCustom) {
+      throw new Error('Cannot delete non-custom entry')
+    }
+    
+    await store.delete(uid)
+    
+    return new Promise((resolve, reject) => {
+      tx.oncomplete = () => {
+        console.log(`Deleted custom ${type}:`, uid)
+        resolve()
+      }
+      tx.onerror = () => reject(tx.error)
+    })
+  } catch (err) {
+    console.error('Failed to delete custom entry:', err)
+    throw err
+  }
+}
+
+/**
+ * Get combined data (API + custom entries)
+ * @param {string} type - 'art', 'camp', or 'event'
+ * @param {string} year - Year as string
+ * @returns {Promise<Array>} Combined array sorted by name
+ */
+export async function getCombinedData(type, year) {
+  try {
+    const database = await openDb()
+    const tx = database.transaction(type, 'readonly')
+    const store = tx.objectStore(type)
+    
+    const yearIndex = store.index('year')
+    const range = IDBKeyRange.only(parseInt(year))
+    
+    return new Promise((resolve, reject) => {
+      const request = yearIndex.getAll(range)
+      request.onsuccess = () => {
+        const results = request.result
+        // Sort by name (custom entries first if same name)
+        results.sort((a, b) => {
+          const nameA = (a.name || a.title || '').toLowerCase()
+          const nameB = (b.name || b.title || '').toLowerCase()
+          if (nameA === nameB) {
+            // Put custom entries first
+            return (b.isCustom ? 1 : 0) - (a.isCustom ? 1 : 0)
+          }
+          return nameA.localeCompare(nameB)
+        })
+        resolve(results)
+      }
+      request.onerror = () => reject(request.error)
+    })
+  } catch (err) {
+    console.error('Failed to get combined data:', err)
+    return []
+  }
+}
+
+/**
+ * Export custom entries to JSON
+ * @param {string} year - Year to export
+ * @returns {Promise<Object>} Export data object
+ */
+export async function exportCustomEntries(year) {
+  try {
+    const camps = await getCustomEntries('camp', year)
+    const art = await getCustomEntries('art', year)
+    const events = await getCustomEntries('event', year)
+    
+    return {
+      version: 1,
+      exportDate: new Date().toISOString(),
+      year: parseInt(year),
+      data: {
+        camps,
+        art,
+        events
+      }
+    }
+  } catch (err) {
+    console.error('Failed to export custom entries:', err)
+    throw err
+  }
+}
+
+/**
+ * Import custom entries from JSON
+ * @param {Object} exportData - Export data object
+ * @returns {Promise<Object>} Import results
+ */
+export async function importCustomEntries(exportData) {
+  try {
+    if (!exportData || exportData.version !== 1) {
+      throw new Error('Invalid export data format')
+    }
+    
+    const results = {
+      camps: 0,
+      art: 0,
+      events: 0,
+      errors: []
+    }
+    
+    // Import each type
+    for (const type of ['camps', 'art', 'events']) {
+      const singularType = type.slice(0, -1) // Remove 's'
+      const entries = exportData.data[type] || []
+      
+      for (const entry of entries) {
+        try {
+          // Generate new ID to avoid conflicts
+          const newEntry = {
+            ...entry,
+            uid: generateCustomId(singularType),
+            importedAt: new Date().toISOString(),
+            importedFrom: entry.uid
+          }
+          await saveCustomEntry(singularType, newEntry)
+          results[type]++
+        } catch (err) {
+          results.errors.push(`Failed to import ${singularType}: ${entry.name || entry.title}`)
+        }
+      }
+    }
+    
+    return results
+  } catch (err) {
+    console.error('Failed to import custom entries:', err)
+    throw err
+  }
+}
+
+/**
+ * Format location object to string
+ * @param {Object} location - Location object
+ * @returns {string} Formatted location string
+ */
+function formatLocationString(location) {
+  if (!location) return ''
+  
+  if (location.intersection && location.intersection_type) {
+    return `${location.intersection} ${location.intersection_type} ${location.street || ''}`
+  }
+  
+  if (location.gps_latitude && location.gps_longitude) {
+    return `GPS: ${location.gps_latitude}, ${location.gps_longitude}`
+  }
+  
+  return location.string || ''
+}
+
+// Re-export openDb for components to use
+export { openDb } from './storage'

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -7,7 +7,7 @@ let db = null
 /**
  * Open the IndexedDB database
  */
-function openDb() {
+export function openDb() {
   return new Promise((resolve, reject) => {
     if (db) {
       resolve(db)
@@ -62,7 +62,7 @@ export async function saveToCache(type, year, items) {
     console.log(`Saving ${items.length} ${type}s for year ${year} to cache`)
     const database = await openDb()
     
-    // First transaction: delete old items
+    // First transaction: delete old non-custom items
     const deleteTx = database.transaction(type, 'readwrite')
     const deleteStore = deleteTx.objectStore(type)
     
@@ -76,8 +76,11 @@ export async function saveToCache(type, year, items) {
         deleteRequest.onsuccess = (e) => {
           const cursor = e.target.result
           if (cursor) {
-            deleteStore.delete(cursor.primaryKey)
-            deletedCount++
+            // Only delete non-custom entries
+            if (!cursor.value.isCustom) {
+              deleteStore.delete(cursor.primaryKey)
+              deletedCount++
+            }
             cursor.continue()
           } else {
             // No more items to delete

--- a/src/views/DetailView.vue
+++ b/src/views/DetailView.vue
@@ -11,6 +11,10 @@
         >
           {{ isFavorited ? '★' : '☆' }}
         </button>
+        <span v-if="item.isCustom" class="custom-badge">
+          <span class="badge-icon">✏️</span>
+          <span class="badge-text">CUSTOM ENTRY</span>
+        </span>
       </h2>
 
       <div id="detail-info">
@@ -24,6 +28,10 @@
           >
             {{ isFavorited ? '★' : '☆' }}
           </button>
+          <span v-if="item.isCustom" class="custom-badge">
+          <span class="badge-icon">✏️</span>
+          <span class="badge-text">CUSTOM ENTRY</span>
+        </span>
         </h2>
         
         <div class="detail-field" v-if="item.description">
@@ -707,6 +715,36 @@ h2 {
 
 .favorite-btn-detail.active {
   color: #FFD700;
+}
+
+.custom-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 1rem;
+  padding: 0.375rem 0.875rem;
+  background: #8B0000;
+  color: #fff;
+  font-weight: 600;
+  border-radius: 20px;
+  vertical-align: middle;
+  line-height: 1;
+}
+
+.badge-icon {
+  font-size: 1rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  margin-right: 0.375rem;
+}
+
+.badge-text {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  line-height: 1;
+  display: flex;
+  align-items: center;
 }
 
 .visit-tracking {


### PR DESCRIPTION
## Summary
- Adds ability to create custom camps, art installations, and events not in official API data
- Implements floating action button (+) on list views for easy access
- Provides type-specific forms with validation and dark theme styling

## Implementation Details
- Base  component with slots for reusability
- Type-specific forms (CustomCampForm, CustomArtForm, CustomEventForm) extend the base
-  service handles CRUD operations with IndexedDB storage
- Modified  to preserve custom entries during API data syncs
- Visual indicators (✏️ icon) distinguish custom entries from official data
- Auto-open feature for filtered groups with 5 or fewer items

## Features
- **Location Selection**: Dual-mode location picker (intersection or GPS coordinates)
- **Form Validation**: Required fields, email/URL validation
- **Data Persistence**: Custom entries survive API data refreshes
- **Mobile Optimized**: Responsive forms and FAB positioning
- **Dark Theme**: Consistent styling with deep selectors for slotted content

## Testing
- Tested on mobile (390x844) and desktop (1280x720) viewports
- Verified custom entries appear in searches and can be favorited
- Confirmed entries persist through data syncs
- Fixed DataCloneError by creating plain objects for IndexedDB

Closes #19